### PR TITLE
chore: add release config and update repo name

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   js-test-and-release:
-    uses: ipdxco/unified-github-workflows/.github/workflows/js-test-and-release.yml@v0.0
+    uses: ipdxco/unified-github-workflows/.github/workflows/js-test-and-release.yml@v1.0
     secrets:
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -63,27 +63,27 @@ main()
 # Install
 
 ```console
-$ npm i @libp2p/whatwg-fetch
+$ npm i @libp2p/http-fetch
 ```
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `Libp2pWhatwgFetch` in the global namespace.
+Loading this module through a script tag will make it's exports available as `Libp2pHttpFetch` in the global namespace.
 
 ```html
-<script src="https://unpkg.com/@libp2p/whatwg-fetch/dist/index.min.js"></script>
+<script src="https://unpkg.com/@libp2p/http-fetch/dist/index.min.js"></script>
 ```
 
 # API Docs
 
-- <https://libp2p.github.io/js-libp2p-whatwg-fetch>
+- <https://libp2p.github.io/js-libp2p-http-fetch>
 
 # License
 
 Licensed under either of
 
-- Apache 2.0, ([LICENSE-APACHE](https://github.com/libp2p/js-libp2p-whatwg-fetch/LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT ([LICENSE-MIT](https://github.com/libp2p/js-libp2p-whatwg-fetch/LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+- Apache 2.0, ([LICENSE-APACHE](https://github.com/libp2p/js-libp2p-http-fetch/LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](https://github.com/libp2p/js-libp2p-http-fetch/LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
 # Contribution
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,91 @@
       "sourceType": "module"
     }
   },
+  "release": {
+    "branches": [
+      "main"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits",
+          "releaseRules": [
+            {
+              "breaking": true,
+              "release": "major"
+            },
+            {
+              "revert": true,
+              "release": "patch"
+            },
+            {
+              "type": "feat",
+              "release": "minor"
+            },
+            {
+              "type": "fix",
+              "release": "patch"
+            },
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "deps",
+              "release": "patch"
+            },
+            {
+              "scope": "no-release",
+              "release": false
+            }
+          ]
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits",
+          "presetConfig": {
+            "types": [
+              {
+                "type": "feat",
+                "section": "Features"
+              },
+              {
+                "type": "fix",
+                "section": "Bug Fixes"
+              },
+              {
+                "type": "chore",
+                "section": "Trivial Changes"
+              },
+              {
+                "type": "docs",
+                "section": "Documentation"
+              },
+              {
+                "type": "deps",
+                "section": "Dependencies"
+              },
+              {
+                "type": "test",
+                "section": "Tests"
+              }
+            ]
+          }
+        }
+      ],
+      "@semantic-release/changelog",
+      "@semantic-release/npm",
+      "@semantic-release/github",
+      "@semantic-release/git"
+    ]
+  },
   "scripts": {
     "build": "aegir build",
     "test": "aegir test",
@@ -50,7 +135,8 @@
     "test:node": "aegir test -t node --cov",
     "dep-check": "aegir dep-check",
     "doc-check": "aegir doc-check",
-    "docs": "aegir docs"
+    "docs": "aegir docs",
+    "release": "aegir release"
   },
   "dependencies": {
     "@libp2p/interface": "^1.2.0",


### PR DESCRIPTION
Updates readme and package.json with new repo name so all the links will be right on npm & adds release config missed from #4.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works