### PR TITLE
feat: Support `PeerId | Multiaddr` for peer targets

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -6,6 +6,7 @@
     "@chainsafe/libp2p-yamux": "^6.0.2",
     "@hono/node-server": "^1.11.2",
     "@libp2p/http-fetch": "file:..",
+    "@libp2p/peer-id": "^4.1.3",
     "@libp2p/tcp": "^9.0.26",
     "@multiformats/multiaddr": "^12.3.0",
     "@multiformats/multiaddr-to-uri": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^5.4.1",
     "@libp2p/logger": "^4.0.10",
+    "@libp2p/peer-id": "^4.1.3",
     "aegir": "^43.0.1",
     "it-pair": "^2.0.6",
     "libp2p": "^1.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@
  */
 
 import { WHATWGFetch, type ProtosMap } from './whatwg-fetch-service.js'
-import type { ComponentLogger } from '@libp2p/interface'
+import type { ComponentLogger, PeerId } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
@@ -52,10 +52,10 @@ export interface HTTP {
 
   // Uses the peer's .well-known endpoint to find where it hosts a given protocol.
   // Throws an error if the peer does not serve the protocol.
-  prefixForProtocol (peer: Multiaddr, protocol: string): Promise<string>
+  prefixForProtocol (peer: PeerId | Multiaddr, protocol: string): Promise<string>
 
   // Get the .well-known protocols for a peer.
-  getPeerMeta (peer: Multiaddr): Promise<ProtosMap>
+  getPeerMeta (peer: PeerId | Multiaddr): Promise<ProtosMap>
 
   // handleHTTPProtocol registers a handler for the given protocol on the given path. This is incompatible with a customHTTPHandler.
   handleHTTPProtocol (protocol: string, path: string, handler: (req: Request) => Promise<Response>): void

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@
  * ```
  */
 
-import { WHATWGFetch } from './whatwg-fetch-service.js'
+import { WHATWGFetch, type ProtosMap } from './whatwg-fetch-service.js'
 import type { ComponentLogger } from '@libp2p/interface'
 import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -49,9 +49,13 @@ export { WELL_KNOWN_PROTOCOLS } from './constants.js'
  */
 export interface HTTP {
   fetch(request: string | Request, requestInit?: RequestInit): Promise<Response>
+
   // Uses the peer's .well-known endpoint to find where it hosts a given protocol.
   // Throws an error if the peer does not serve the protocol.
   prefixForProtocol (peer: Multiaddr, protocol: string): Promise<string>
+
+  // Get the .well-known protocols for a peer.
+  getPeerMeta (peer: Multiaddr): Promise<ProtosMap>
 
   // handleHTTPProtocol registers a handler for the given protocol on the given path. This is incompatible with a customHTTPHandler.
   handleHTTPProtocol (protocol: string, path: string, handler: (req: Request) => Promise<Response>): void

--- a/src/ping.ts
+++ b/src/ping.ts
@@ -32,7 +32,7 @@ export async function servePing (req: Request): Promise<Response> {
  * Send a ping request to a peer
  *
  * @param node - a libp2p node
- * @param peer - Target peer
+ * @param peerIdOrMultiaddr - Target peer
  */
 export async function sendPing (node: Libp2p<{ http: HTTP }>, peerIdOrMultiaddr: PeerId | Multiaddr): Promise<void> {
   const peerAddr: Multiaddr = isPeerId(peerIdOrMultiaddr) ? multiaddr(`/p2p/${peerIdOrMultiaddr.toString()}`) : peerIdOrMultiaddr

--- a/src/ping.ts
+++ b/src/ping.ts
@@ -1,7 +1,7 @@
 // http-ping implementation
-import { type Multiaddr } from '@multiformats/multiaddr'
+import { isPeerId, type Libp2p, type PeerId } from '@libp2p/interface'
+import { multiaddr, type Multiaddr } from '@multiformats/multiaddr'
 import type { HTTP } from './index.js'
-import type { Libp2p } from '@libp2p/interface'
 
 const PING_SIZE = 32
 export const PING_PROTOCOL_ID = '/http-ping/1'
@@ -32,14 +32,15 @@ export async function servePing (req: Request): Promise<Response> {
  * Send a ping request to a peer
  *
  * @param node - a libp2p node
- * @param peer - A peer's multiaddr
+ * @param peer - Target peer
  */
-export async function sendPing (node: Libp2p<{ http: HTTP }>, peer: Multiaddr): Promise<void> {
+export async function sendPing (node: Libp2p<{ http: HTTP }>, peerIdOrMultiaddr: PeerId | Multiaddr): Promise<void> {
+  const peerAddr: Multiaddr = isPeerId(peerIdOrMultiaddr) ? multiaddr(`/p2p/${peerIdOrMultiaddr.toString()}`) : peerIdOrMultiaddr
   const buf = new Uint8Array(PING_SIZE)
   // Fill buffer with random data
   crypto.getRandomValues(buf)
-  const pingEndpoint = await node.services.http.prefixForProtocol(peer, PING_PROTOCOL_ID)
-  const requestURL = 'multiaddr:' + peer.encapsulate(`/http-path/${encodeURIComponent(pingEndpoint)}`).toString()
+  const pingEndpoint = await node.services.http.prefixForProtocol(peerAddr, PING_PROTOCOL_ID)
+  const requestURL = 'multiaddr:' + peerAddr.encapsulate(`/http-path/${encodeURIComponent(pingEndpoint)}`).toString()
 
   const resp = await node.services.http.fetch(new Request(requestURL, {
     method: 'POST',


### PR DESCRIPTION
closes #1, #2.
