### PR TITLE
fix: Fail if an HTTP transport and peer id are both present

### DIFF
--- a/src/whatwg-fetch-service.ts
+++ b/src/whatwg-fetch-service.ts
@@ -123,6 +123,9 @@ export class WHATWGFetch implements Startable, WHATWGFetchInterface {
       const peerWithoutHTTPPath = ma.decapsulateCode(protocols('http-path').code)
 
       if (this.isHTTPTransportMultiaddr(peerWithoutHTTPPath)) {
+        if (peerWithoutHTTPPath.getPeerId() !== null) {
+          throw new Error('HTTP Transport does not yet support peer IDs. Use a stream based transport instead.')
+        }
         const [, httpPathVal] = ma.stringTuples().find(([code]) =>
           code === protocols('http-path').code
         ) ?? ['', '']
@@ -166,7 +169,13 @@ export class WHATWGFetch implements Startable, WHATWGFetchInterface {
       throw new Error('peer multiaddr must have at least one part')
     }
 
-    return parts[parts.length - 1].name === 'http' || parts[parts.length - 1].name === 'https'
+    // Reverse order for faster common case (/http is near the end)
+    for (let i = parts.length - 1; i >= 0; i--) {
+      if (parts[i].name === 'http' || parts[i].name === 'https') {
+        return true
+      }
+    }
+    return false
   }
 
   // Register a protocol with a path and remember it so we can tell our peers
@@ -212,6 +221,9 @@ export class WHATWGFetch implements Startable, WHATWGFetchInterface {
     let fetch
     let reqUrl = ''
     if (this.isHTTPTransportMultiaddr(peerAddr)) {
+      if (peerAddr.getPeerId() !== null) {
+        throw new Error('HTTP Transport does not yet support peer IDs. Use a stream based transport instead.')
+      }
       fetch = this._fetch
       reqUrl = `${multiaddrToUri(peerAddr)}${WELL_KNOWN_PROTOCOLS}`
     } else {

--- a/src/whatwg-fetch-service.ts
+++ b/src/whatwg-fetch-service.ts
@@ -218,21 +218,8 @@ export class WHATWGFetch implements Startable, WHATWGFetchInterface {
       return cached
     }
 
-    let fetch
-    let reqUrl = ''
-    if (this.isHTTPTransportMultiaddr(peerAddr)) {
-      if (peerAddr.getPeerId() !== null) {
-        throw new Error('HTTP Transport does not yet support peer IDs. Use a stream based transport instead.')
-      }
-      fetch = this._fetch
-      reqUrl = `${multiaddrToUri(peerAddr)}${WELL_KNOWN_PROTOCOLS}`
-    } else {
-      const conn = await this.components.connectionManager.openConnection(peerAddr)
-      const s = await conn.newStream(PROTOCOL_NAME)
-      fetch = fetchViaDuplex(s)
-      reqUrl = multiaddrURIPrefix + peerAddr.encapsulate(`/http-path/${encodeURIComponent(WELL_KNOWN_PROTOCOLS)}`).toString()
-    }
-    const resp = await fetch(new Request(reqUrl, {
+    const reqUrl = multiaddrURIPrefix + peerAddr.encapsulate(`/http-path/${encodeURIComponent(WELL_KNOWN_PROTOCOLS)}`).toString()
+    const resp = await this.fetch(new Request(reqUrl, {
       method: 'GET',
       headers: {
         Accept: 'application/json'

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -5,6 +5,7 @@ import { streamPair } from '@libp2p/interface-compliance-tests/mocks'
 import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { multiaddr, type Multiaddr, type Protocol } from '@multiformats/multiaddr'
+import { expect } from 'aegir/chai'
 import { duplexPair } from 'it-pair/duplex'
 import { type Libp2p } from 'libp2p'
 import pDefer from 'p-defer'
@@ -94,5 +95,11 @@ describe('whatwg-fetch', () => {
     const clientNode = stubInterface<Libp2p<{ http: HTTP }>>({ services: { http: client } })
 
     await ping.sendPing(clientNode, serverPeerID)
+  })
+
+  it('Throws an error if using an http transport with a peer id component', async () => {
+    const clientNode = stubInterface<Libp2p<{ http: HTTP }>>({ services: { http: client } })
+
+    await expect(ping.sendPing(clientNode, multiaddr('/ip4/127.0.0.1/http/p2p/' + serverPeerID.toString()))).to.be.rejectedWith('HTTP Transport does not yet support peer IDs')
   })
 })


### PR DESCRIPTION
closes #12 

We don't yet have an auth scheme that authenticates a peer id over an HTTP transport. We do have a [draft spec](https://github.com/libp2p/specs/pull/564), but it is not implemented. I'm working on the go-libp2p version now and should have the js-libp2p version soon.