### PR TITLE
fix: allow aborting authentication

### DIFF
--- a/examples/peer-id-auth/node.js
+++ b/examples/peer-id-auth/node.js
@@ -15,7 +15,7 @@ const args = process.argv.slice(2)
 if (args.length === 1 && args[0] === 'client') {
   // Client mode
   const client = new ClientAuth(privKey)
-  const observedPeerID = await client.authenticateServer(fetch, 'localhost:8001', 'http://localhost:8001/auth')
+  const observedPeerID = await client.authenticateServer('http://localhost:8001/auth')
   console.log('Server ID:', observedPeerID.toString())
 
   const authenticatedReq = new Request('http://localhost:8001/log-my-id', {

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -3,13 +3,27 @@ import { peerIdFromPublicKey } from '@libp2p/peer-id'
 import { toString as uint8ArrayToString, fromString as uint8ArrayFromString } from 'uint8arrays'
 import { parseHeader, PeerIDAuthScheme, sign, verify } from './common.js'
 import type { PeerId, PrivateKey } from '@libp2p/interface'
-
-interface Fetch { (input: RequestInfo, init?: RequestInit): Promise<Response> }
+import type { AbortOptions } from '@multiformats/multiaddr'
 
 interface tokenInfo {
   creationTime: Date
   bearer: string
   peer: PeerId
+}
+
+export interface AuthenticateServerOptions extends AbortOptions {
+  /**
+   * The Fetch implementation to use
+   *
+   * @default globalThis.fetch
+   */
+  fetch?: typeof globalThis.fetch
+
+  /**
+   * The hostname to use - by default this will be extracted from the
+   * `authEndpointURI`
+   */
+  hostname?: string
 }
 
 export class ClientAuth {
@@ -49,7 +63,10 @@ export class ClientAuth {
     return `${PeerIDAuthScheme} bearer="${token.bearer}"`
   }
 
-  public async authenticateServer (fetch: Fetch, hostname: string, authEndpointURI: string): Promise<PeerId> {
+  public async authenticateServer (authEndpointURI: string | URL, options?: AuthenticateServerOptions): Promise<PeerId> {
+    authEndpointURI = new URL(authEndpointURI)
+    const hostname = options?.hostname ?? authEndpointURI.hostname
+
     if (this.tokens.has(hostname)) {
       const token = this.tokens.get(hostname)
       if (token !== undefined && Date.now() - token.creationTime.getTime() < this.tokenTTL) {
@@ -70,7 +87,11 @@ export class ClientAuth {
       })
     }
 
-    const resp = await fetch(authEndpointURI, { headers })
+    const fetch = options?.fetch ?? globalThis.fetch
+    const resp = await fetch(authEndpointURI, {
+      headers,
+      signal: options?.signal
+    })
 
     // Verify the server's challenge
     const authHeader = resp.headers.get('www-authenticate')
@@ -102,7 +123,8 @@ export class ClientAuth {
     const resp2 = await fetch(authEndpointURI, {
       headers: {
         Authorization: authenticateSelfHeaders
-      }
+      },
+      signal: options?.signal
     })
 
     // Verify the server's signature

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -20,8 +20,8 @@ export interface AuthenticateServerOptions extends AbortOptions {
   fetch?: typeof globalThis.fetch
 
   /**
-   * The hostname to use - by default this will be extracted from the
-   * `authEndpointURI`
+   * The hostname to use - by default this will be extracted from the `.host`
+   * property of `authEndpointURI`
    */
   hostname?: string
 }
@@ -65,7 +65,7 @@ export class ClientAuth {
 
   public async authenticateServer (authEndpointURI: string | URL, options?: AuthenticateServerOptions): Promise<PeerId> {
     authEndpointURI = new URL(authEndpointURI)
-    const hostname = options?.hostname ?? authEndpointURI.hostname
+    const hostname = options?.hostname ?? authEndpointURI.host
 
     if (this.tokens.has(hostname)) {
       const token = this.tokens.get(hostname)

--- a/test/auth/index.spec.ts
+++ b/test/auth/index.spec.ts
@@ -38,6 +38,22 @@ describe('HTTP Peer ID Authentication', () => {
     expect(observedServerPeerId.equals(server)).to.be.true()
   })
 
+  it('Should mutually authenticate with a custom port', async () => {
+    const clientAuth = new ClientAuth(clientKey)
+    const serverAuth = new ServerAuth(serverKey, h => h === 'foobar:12345')
+
+    const fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const req = new Request(input, init)
+      const resp = await serverAuth.httpHandler(req)
+      return resp
+    }
+
+    const observedServerPeerId = await clientAuth.authenticateServer('https://foobar:12345/auth', {
+      fetch
+    })
+    expect(observedServerPeerId.equals(server)).to.be.true()
+  })
+
   it('Should time out when authenticating', async () => {
     const clientAuth = new ClientAuth(clientKey)
 

--- a/test/auth/index.spec.ts
+++ b/test/auth/index.spec.ts
@@ -26,14 +26,28 @@ describe('HTTP Peer ID Authentication', () => {
     const clientAuth = new ClientAuth(clientKey)
     const serverAuth = new ServerAuth(serverKey, h => h === 'example.com')
 
-    const fetch = async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
+    const fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
       const req = new Request(input, init)
       const resp = await serverAuth.httpHandler(req)
       return resp
     }
 
-    const observedServerPeerId = await clientAuth.authenticateServer(fetch, 'example.com', 'https://example.com/auth')
+    const observedServerPeerId = await clientAuth.authenticateServer('https://example.com/auth', {
+      fetch
+    })
     expect(observedServerPeerId.equals(server)).to.be.true()
+  })
+
+  it('Should time out when authenticating', async () => {
+    const clientAuth = new ClientAuth(clientKey)
+
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(clientAuth.authenticateServer('https://example.com/auth', {
+      signal: controller.signal
+    })).to.eventually.be.rejected
+      .with.property('name', 'AbortError')
   })
 
   it('Should match the test vectors', async () => {


### PR DESCRIPTION
Allows passing an abort signal to `authenticateServer` to give the caller control of when to give up waiting for the server response.

Also allows passing a `URL` as the auth endpoint and allows overriding the hostname/fetch implementations as options instead of requiring them to be passed explicitly.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works