### PR TITLE
fix: do not require a 200 from the auth endpoint

### DIFF
--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -110,9 +110,6 @@ export class ClientAuth {
     if (serverAuthHeader == null) {
       throw new Error('No server auth header')
     }
-    if (resp2.status !== 200) {
-      throw new Error('Unexpected status code')
-    }
 
     const serverAuthFields = parseHeader(serverAuthHeader)
     const serverPublicKey = publicKeyFromProtobuf(serverPubKeyBytes)


### PR DESCRIPTION
Some endpoints may require other fields to be passed to the auth endpoint which may result in a non-200 response.

Others may send a different success code (such as 204) so be less strict about the response code, as long as they've sent us the `Authentication-Info` header.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works