### PR TITLE
fix: log correct response status

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: lts/*
       - run: npm i
         working-directory: ./examples
-      - uses: ipfs/aegir/actions/cache-node-modules@master
+      - uses: ipfs/aegir/actions/cache-node-modules@main
         with:
           directories: |
             ./examples/node_modules
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@master
+      - uses: ipfs/aegir/actions/cache-node-modules@main
         with:
           directories: |
             ./examples/node_modules

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -189,7 +189,7 @@ export class ClientAuth {
     const resp2 = await fetch(request)
 
     if (!resp2.ok) {
-      throw new BadResponseError(`Unexpected status code ${resp.status}`)
+      throw new BadResponseError(`Unexpected status code ${resp2.status}`)
     }
 
     const serverAuthHeader = resp2.headers.get('Authentication-Info')


### PR DESCRIPTION
When the second request fails, log the status of the second request, not the first.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works