### PR TITLE
feat: support cookies between requests

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,8 @@
+/** @type {import('aegir').PartialOptions} */
+export default {
+  dependencyCheck: {
+    ignore: [
+      'undici' // required by http-cookie-agent
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -174,10 +174,13 @@
     "@multiformats/multiaddr": "^12.3.0",
     "@multiformats/multiaddr-to-uri": "^11.0.0",
     "@perseveranza-pets/milo": "^0.2.1",
+    "http-cookie-agent": "^6.0.7",
     "p-defer": "^4.0.1",
+    "tough-cookie": "^5.0.0",
     "uint8-varint": "^2.0.4",
     "uint8arraylist": "^2.4.8",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^5.1.0",
+    "undici": "^6.21.0"
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^6.1.8",
@@ -186,6 +189,9 @@
     "it-pair": "^2.0.6",
     "libp2p": "^2.2.1",
     "sinon-ts": "^2.0.0"
+  },
+  "browser": {
+    "./dist/src/auth/agent.js": "./dist/src/auth/agent.browser.js"
   },
   "sideEffects": false
 }

--- a/src/auth/agent.browser.ts
+++ b/src/auth/agent.browser.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns nothing as browsers handle cookies for us
+ */
+export function getAgent (): any {
+  return {
+    agent: undefined,
+    jar: {
+      getCookies: () => []
+    }
+  }
+}

--- a/src/auth/agent.ts
+++ b/src/auth/agent.ts
@@ -1,0 +1,18 @@
+import { CookieAgent } from 'http-cookie-agent/undici'
+import { CookieJar } from 'tough-cookie'
+
+/**
+ * Returns an HTTP Agent that handles cookies over multiple requests
+ */
+export function getAgent (): { agent: CookieAgent, jar: CookieJar } {
+  const jar = new CookieJar()
+
+  return {
+    agent: new CookieAgent({
+      cookies: {
+        jar
+      }
+    }),
+    jar
+  }
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -58,7 +58,7 @@ describe('whatwg-fetch', () => {
       return streams[1]
     })
 
-    clientComponents.connectionManager.openConnection.callsFake(async (peer: PeerId | Multiaddr | Multiaddr[], options?: any) => {
+    clientComponents.connectionManager.openConnection.callsFake(async (peer: PeerId | Multiaddr | Multiaddr[]) => {
       if (Array.isArray(peer)) {
         peer = peer[0]
       }

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,0 +1,99 @@
+import http from 'node:http'
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { expect } from 'aegir/chai'
+import pDefer from 'p-defer'
+import { ClientAuth, ServerAuth } from '../src/auth/index.js'
+import type { PeerId, PrivateKey } from '@libp2p/interface'
+
+describe('@libp2p/http-fetch', () => {
+  describe('client auth', () => {
+    let clientKey: PrivateKey
+    let serverKey: PrivateKey
+    let server: http.Server
+
+    beforeEach(async () => {
+      clientKey = await generateKeyPair('Ed25519')
+      serverKey = await generateKeyPair('Ed25519')
+    })
+
+    afterEach(async () => {
+      server?.close()
+      server?.closeAllConnections()
+    })
+
+    it('should perform auth from client', async () => {
+      const clientAuth = new ClientAuth(clientKey)
+      const serverAuth = new ServerAuth(serverKey, h => h.startsWith('127.0.0.1'))
+      const clientPeer = pDefer<PeerId>()
+      const echoListener = serverAuth.requestListener((clientId, req, res) => {
+        clientPeer.resolve(clientId)
+        req.pipe(res)
+      })
+
+      server = http.createServer(echoListener)
+
+      const port = await new Promise<number>((resolve, reject) => {
+        const listener = server.listen(0, () => {
+          const address = listener.address()
+
+          if (address == null || typeof address === 'string') {
+            reject(new Error('Could not listen on port'))
+            return
+          }
+
+          resolve(address.port)
+        })
+      })
+
+      await expect(clientAuth.authenticateServer(`http://127.0.0.1:${port}`)).to.eventually.deep.equal(peerIdFromPrivateKey(serverKey))
+      await expect(clientPeer.promise).to.eventually.deep.equal(peerIdFromPrivateKey(clientKey))
+    })
+
+    it('should respect cookies during auth', async () => {
+      const clientAuth = new ClientAuth(clientKey)
+      const serverAuth = new ServerAuth(serverKey, h => h.startsWith('127.0.0.1'))
+      const cookie = pDefer<string>()
+      const echoListener = serverAuth.requestListener((clientId, req, res) => {
+        req.pipe(res)
+      })
+      const cookieName = 'test-cookie-name'
+      const cookieValue = 'test-cookie-value'
+      let requests = 0
+
+      server = http.createServer((req, res) => {
+        requests++
+
+        const cookieHeader = req.headers.cookie
+
+        if (cookieHeader == null) {
+          if (requests === 2) {
+            cookie.reject(new Error('No cookie header found on second request'))
+          }
+
+          res.setHeader('set-cookie', `${cookieName}=${cookieValue}; Expires=${new Date(Date.now() + 86_400_000).toString()}; HttpOnly`)
+        } else {
+          cookie.resolve(cookieHeader)
+        }
+
+        echoListener(req, res)
+      })
+
+      const port = await new Promise<number>((resolve, reject) => {
+        const listener = server.listen(0, () => {
+          const address = listener.address()
+
+          if (address == null || typeof address === 'string') {
+            reject(new Error('Could not listen on port'))
+            return
+          }
+
+          resolve(address.port)
+        })
+      })
+
+      await expect(clientAuth.authenticateServer(`http://127.0.0.1:${port}`)).to.eventually.deep.equal(peerIdFromPrivateKey(serverKey))
+      await expect(cookie.promise).to.eventually.equal(`${cookieName}=${cookieValue}`)
+    })
+  })
+})


### PR DESCRIPTION
Uses the `http-cookie-agent` module to add cookie support to Node.js.

Browsers manage cookies for us so the added functions are swapped out for empty implementations.

Fixes #16

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works