### PR TITLE
fix: replace @perseveranza-pets/milo with @achingbrain/http-parser-js

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,7 @@
+
+/** @type {import('aegir/types').PartialOptions} */
+export default {
+  build: {
+    bundlesizeMax: '18kB'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -174,8 +174,6 @@
     "@libp2p/peer-id": "^5.0.7",
     "@multiformats/multiaddr": "^12.3.0",
     "@multiformats/multiaddr-to-uri": "^11.0.0",
-    "buffer": "^6.0.3",
-    "http-parser-js": "^0.5.9",
     "p-defer": "^4.0.1",
     "uint8-varint": "^2.0.4",
     "uint8arraylist": "^2.4.8",

--- a/package.json
+++ b/package.json
@@ -167,13 +167,15 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "@achingbrain/http-parser-js": "^0.5.8",
     "@libp2p/crypto": "^5.0.6",
     "@libp2p/interface": "^2.2.0",
     "@libp2p/interface-internal": "^2.0.10",
     "@libp2p/peer-id": "^5.0.7",
     "@multiformats/multiaddr": "^12.3.0",
     "@multiformats/multiaddr-to-uri": "^11.0.0",
-    "@perseveranza-pets/milo": "^0.2.1",
+    "buffer": "^6.0.3",
+    "http-parser-js": "^0.5.9",
     "p-defer": "^4.0.1",
     "uint8-varint": "^2.0.4",
     "uint8arraylist": "^2.4.8",


### PR DESCRIPTION
`@achingbrain/http-parser-js` is a fork of `http-parser-js` that converts it to ESM and uses `Uint8Array`s instead of node `Buffer`s.  It is 6.6kb.

`@perseveranza-pets/milo` is 84.7kb.

Fixes #35

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works